### PR TITLE
chore: add CI workflow, security policy, and repo hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Java 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244  # v4.3.1
+
+      - name: Build and test
+        run: ./gradlew check
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: test-reports
+          path: |
+            app/build/reports/tests/
+            app/build/reports/bdd-test/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Ignore Gradle build output directory
 build
 /.idea/
+tmp/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x     | ✓         |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+To report a vulnerability, use [GitHub's private vulnerability reporting](https://github.com/Arc-E-Tect/sedr-wiremock-cucumber-experiment/security/advisories/new).
+
+You can expect:
+- Acknowledgement within **5 business days**
+- A resolution or workaround target within **30 days** for confirmed vulnerabilities
+
+Please include as much detail as possible: affected version(s), steps to reproduce, and potential impact.


### PR DESCRIPTION
## Summary

Hardens the repository configuration for public visibility.

### Changes

- **`.github/workflows/ci.yml`** — CI pipeline that runs `./gradlew check` (unit + BDD tests) on every push and PR targeting `main`. All action references are SHA-pinned.
- **`SECURITY.md`** — Security policy directing vulnerability reporters to GitHub's private advisory form.
- **`.gitignore`** — Added `tmp/` entry.

### GitHub settings applied (via API)

| Setting | Value |
|---|---|
| Branch ruleset `main-branch-rule` | Enabled; squash-only; `build` CI check required; no bypass actors |
| Allowed merge methods | Squash only |
| Delete branch on merge | true |
| Actions SHA pinning | Required |
